### PR TITLE
Introduce --respect-mtu flag

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,10 @@ systemd-socket-activate -d -l 69 s3tftpd s3://bucket/prefix/
   Timeout in milliseconds before the server retransmits a packet. Default: 5000
 
 *-b*, *--blocksize*=_OCTETS_::
-  Specifies maximum permitted block size in octets. Actual block size is negotiated with the client by `blksize` extension (RFC 2348). Limitation: Maximum block size is clamped to the interface MTU minus header size. Default: 512
+  Specifies maximum permitted block size in octets. Actual block size is negotiated with the client by `blksize` extension (RFC 2348). Default: 512
+
+*--respect-mtu*::
+  Clamps negotiated block size to the interface MTU minus protocol overhead. By default, s3tftpd honors the client-requested block size without MTU-based restriction.
 
 *--anticipate*=_WINDOW-SIZE_::
   [experimental] Enables sender anticipation feature, in which the server sends at most _WINDOW-SIZE_ data blocks before waiting ACK packets from the client. It can improve download speed. Set 0 to disable the feature. Default: 0 (disabled).

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 s3tftpd (0.6.2) UNRELEASED; urgency=medium
 
+  * Introduce --respect-mtu flag; disable MTU-based block size clamping by default
   * Update dependency
 
  -- Kasumi Hanazuki <kasumi@rollingapple.net>  Mon, 16 Mar 2026 16:38:40 +0000

--- a/main.go
+++ b/main.go
@@ -29,7 +29,8 @@ type Args struct {
 	Region         string `name:"region" help:"AWS region where the bucket resides" placeholder:"REGION"`
 	Retries        int    `short:"r" name:"retries" default:"5" help:"Number of retransmissions before the server disconnect the session"`
 	Timeout        int    `short:"t" name:"timeout" default:"5000" help:"Timeout in milliseconds before the server retransmits a packet"`
-	BlockSize      int    `short:"b" name:"blocksize" default:"512" help:"Maximum permitted block size in octets"`
+	BlockSize      int    `short:"b" name:"blocksize" default:"512" help:"Maximum permitted block size in octets (512..65464)"`
+	RespectMTU     bool   `name:"respect-mtu" help:"Clamp negotiated block size to the interface MTU minus protocol overhead"`
 	Anticipate     uint   `name:"anticipate" default:"0" help:"Size of anticipation window. Set 0 to disable sender anticipation (experimental)"`
 	NoDualStack    bool   `name:"no-dualstack" help:"Disable S3 dualstack endpoint"`
 	Accelerate     bool   `name:"accelerate" help:"Enable S3 Transfer Acceleration"`
@@ -240,6 +241,7 @@ func main() {
 	server.SetTimeout(time.Duration(config.Timeout) * time.Millisecond)
 	server.SetRetries(config.Retries)
 	server.SetBlockSize(config.BlockSize)
+	server.SetBlockSizeNegotiation(config.RespectMTU)
 	server.SetAnticipate(config.Anticipate)
 	server.SetHook(config.hooks())
 	if config.SinglePort {


### PR DESCRIPTION
--respect-mtu flag enables MTU-based block size clamping, which is now disabled by default.